### PR TITLE
feat: add IOptions support and auto-provisioning

### DIFF
--- a/PostgresDistributedCacheTests/PostgreSqlDistributedCacheTests.cs
+++ b/PostgresDistributedCacheTests/PostgreSqlDistributedCacheTests.cs
@@ -1,5 +1,3 @@
-
-
 using System.Text;
 using Sats.PostgreSqlDistributedCache;
 
@@ -7,11 +5,17 @@ namespace PostgresDistributedCacheTests;
 
 public class PostgreSqlDistributedCacheTests
 {
-    private readonly string _connectionString = "Server=127.0.0.1;Port=5432;Database=HIS;User Id=postgres;Password=satsvelke@7;";
-
     private PostgreSqlDistributedCache CreateCache()
     {
-        return new PostgreSqlDistributedCache(_connectionString);
+        var options = new PostgresDistributedCacheOptions
+        {
+            ConnectionString = "Server=127.0.0.1;Port=5432;Database=HIS;User Id=postgres;Password=satsvelke@7;",
+            // You can use any valid PostgreSQL schema name. Default is 'public', but you can create and use custom schemas
+            SchemaName = "public",
+            // You can use any table name like 'Cache' or 'cache' according to your preferences
+            TableName = "Cache"
+        };
+        return new PostgreSqlDistributedCache(options);
     }
 
     [Fact]

--- a/PostgresDistributedCacheTests/PostgresDistributedCacheTests.csproj
+++ b/PostgresDistributedCacheTests/PostgresDistributedCacheTests.csproj
@@ -8,12 +8,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Npgsql" Version="9.0.2" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Npgsql" Version="9.0.3" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Sats.PostgresDistributedCache/DistributedCacheServiceExtensions.cs
+++ b/Sats.PostgresDistributedCache/DistributedCacheServiceExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Sats.PostgresDistributedCache;
 
 namespace Sats.PostgreSqlDistributedCache
@@ -8,10 +9,7 @@ namespace Sats.PostgreSqlDistributedCache
         public static IServiceCollection AddPostgresDistributedCache(
             this IServiceCollection services, Action<PostgresDistributedCacheOptions> configureOptions)
         {
-            if (configureOptions == null)
-            {
-                throw new ArgumentNullException(nameof(configureOptions));
-            }
+            ArgumentNullException.ThrowIfNull(configureOptions);
 
             var options = new PostgresDistributedCacheOptions();
             configureOptions(options);
@@ -29,8 +27,45 @@ namespace Sats.PostgreSqlDistributedCache
         }
     }
 
-    public class PostgresDistributedCacheOptions
+    public class PostgresDistributedCacheOptions : IOptions<PostgresDistributedCacheOptions>
     {
-        public string? ConnectionString { get; set; }
+        private string _connectionString;
+
+        public TimeSpan? ExpiredItemsDeletionInterval { get; set; }
+
+        public string ConnectionString
+        {
+            get => this._connectionString;
+            set
+            {
+                this._connectionString = value;
+                if (this.ReadConnectionString == null)
+                    this.ReadConnectionString = value;
+                if (this.WriteConnectionString != null)
+                    return;
+                this.WriteConnectionString = value;
+            }
+        }
+    
+    
+        public string ReadConnectionString { get; set; }
+
+        public string WriteConnectionString { get; set; }
+
+        public string SchemaName { get; set; } = "public";
+
+        public string TableName { get; set; } = "Cache";
+    
+        public TimeSpan DefaultSlidingExpiration { get; set; } = TimeSpan.FromMinutes(20.0);
+    
+        public PostgresDistributedCacheOptions Value
+        {
+            get
+            {
+                this.WriteConnectionString = this.WriteConnectionString ?? this.ConnectionString;
+                this.ReadConnectionString = (this.ReadConnectionString ?? this.ConnectionString) ?? this.WriteConnectionString;
+                return this;
+            }
+        }
     }
 }

--- a/Sats.PostgresDistributedCache/IPostgreSqlDistributedCache.cs
+++ b/Sats.PostgresDistributedCache/IPostgreSqlDistributedCache.cs
@@ -1,4 +1,3 @@
-
 namespace Sats.PostgresDistributedCache;
 
 public interface IPostgreSqlDistributedCache

--- a/Sats.PostgresDistributedCache/Sats.PostgresDistributedCache.csproj
+++ b/Sats.PostgresDistributedCache/Sats.PostgresDistributedCache.csproj
@@ -13,9 +13,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
-    <PackageReference Include="Npgsql" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.4" />
+    <PackageReference Include="Npgsql" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sats.PostgresDistributedCache/readme.md
+++ b/Sats.PostgresDistributedCache/readme.md
@@ -82,13 +82,12 @@ public class MyService
 The cache is stored in a PostgreSQL table named `Cache` with the following schema:
 
 ```sql
-CREATE TABLE IF NOT EXISTS public."Cache"
-(
-    "key" character varying(255) NOT NULL,
-    "value" text NOT NULL,
-    "expiration" timestamp with time zone,
-    CONSTRAINT "PK_Cache" PRIMARY KEY ("key"),
-    CONSTRAINT "UQ_Cache_Key" UNIQUE ("key")
+CREATE TABLE IF NOT EXISTS public."Cache" (
+  key character varying(255) NOT NULL,
+  value bytea NOT NULL,
+  expiration timestamp with time zone,
+  CONSTRAINT PK_Cache PRIMARY KEY (key),
+  CONSTRAINT UQ_Cache_Key UNIQUE (key)  
 );
 ```
 


### PR DESCRIPTION
- **Package bumps**
  - `Npgsql` **9.0.2 → 9.0.3**
  - `Microsoft.Extensions.Caching.Abstractions` **9.0.1 → 9.0.4**
  - `Microsoft.Extensions.DependencyInjection` **9.0.1 → 9.0.4**

- **New dependency**
  - `Microsoft.Extensions.Options` **9.0.4**

- **Options refactor**
  - `PostgresDistributedCacheOptions` now implements `IOptions<PostgresDistributedCacheOptions>`
  - Added `SchemaName` and `TableName` properties (defaults: `public.Cache`)

- **Cache implementation**
  - Kept existing constructor (`connectionString`)
  - **Added** constructor that receives `IOptions<PostgresDistributedCacheOptions>`
  - All SQL statements now honor `SchemaName` and `TableName`
  - Automatic table creation on first use (if it doesn’t exist)
  - Column `value` type switched from `TEXT` → **`BYTEA`** for binary-safe storage
