### PR TITLE
feat: add overload to configure PostgresDistributedCacheOptions using IServiceProvider

### DIFF
--- a/Sats.PostgresDistributedCache/DistributedCacheServiceExtensions.cs
+++ b/Sats.PostgresDistributedCache/DistributedCacheServiceExtensions.cs
@@ -25,6 +25,27 @@ namespace Sats.PostgreSqlDistributedCache
 
             return services;
         }
+
+        public static IServiceCollection AddPostgresDistributedCache(
+            this IServiceCollection services, Action<IServiceProvider, PostgresDistributedCacheOptions> configureOptions)
+        {
+            ArgumentNullException.ThrowIfNull(configureOptions);
+
+            services.AddSingleton<IPostgreSqlDistributedCache>(sp =>
+            {
+                var options = new PostgresDistributedCacheOptions();
+                configureOptions(sp, options);
+
+                if (string.IsNullOrEmpty(options.ConnectionString))
+                {
+                    throw new InvalidOperationException("PostgreSQL cache connection string is missing.");
+                }
+
+                return new PostgreSqlDistributedCache(options.ConnectionString!);
+            });
+
+            return services;
+        }
     }
 
     public class PostgresDistributedCacheOptions : IOptions<PostgresDistributedCacheOptions>


### PR DESCRIPTION
This allows the cache configuration to access other services from the DI container,
enabling scenarios like retrieving settings from IConfiguration or IOptions during setup.
