### PR TITLE
IPostgreSqlDistributedCache with IDistributedCache

### DIFF
--- a/Sats.PostgresDistributedCache/IPostgreSqlDistributedCache.cs
+++ b/Sats.PostgresDistributedCache/IPostgreSqlDistributedCache.cs
@@ -1,6 +1,8 @@
+using Microsoft.Extensions.Caching.Distributed;
+
 namespace Sats.PostgresDistributedCache;
 
-public interface IPostgreSqlDistributedCache
+public interface IPostgreSqlDistributedCache : IDistributedCache
 {
     Task<byte[]?> GetAsync(string key, CancellationToken token = default);
     Task SetAsync(string key, byte[] value, TimeSpan? expiration = null, CancellationToken token = default);

--- a/Sats.PostgresDistributedCache/PostgreSqlDistributedCache.cs
+++ b/Sats.PostgresDistributedCache/PostgreSqlDistributedCache.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Options;
 using Npgsql;
 using Sats.PostgresDistributedCache;
@@ -117,5 +118,18 @@ namespace Sats.PostgreSqlDistributedCache
             var encodedValue = Encoding.UTF8.GetBytes(value);
             await SetAsync(key, encodedValue, expiration, token);
         }
+        
+        public byte[]? Get(string key) => GetAsync(key).GetAwaiter().GetResult();
+
+        public void Set(string key, byte[] value, DistributedCacheEntryOptions options) =>
+            SetAsync(key, value, options).GetAwaiter().GetResult();
+
+        public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options,
+            CancellationToken token = new CancellationToken()) =>
+            SetAsync(key, value, options.AbsoluteExpirationRelativeToNow, token);
+
+        public void Refresh(string key) => RefreshAsync(key).GetAwaiter().GetResult();
+
+        public void Remove(string key) => RemoveAsync(key).GetAwaiter().GetResult();
     }
 }


### PR DESCRIPTION
#### **Summary of changes**

1. **Compliance with the official contract**
   
   - `IPostgreSqlDistributedCache` now derives from `IDistributedCache`, bringing full compatibility with ASP.NET Core middleware and extensions that rely on this interface.

2. **Synchronous method implementation**
   
   - `PostgreSqlDistributedCache` now exposes the four synchronous operations required by `IDistributedCache` (`Get`, `Set`, `Refresh`, `Remove`).
   
   - Each method delegates to the existing async version, preserving current logic and avoiding duplication.

3. **Added usings**
   
   - `using Microsoft.Extensions.Caching.Distributed;` was added to both files for explicit reference to the interface.

#### 📝 **Motivation**

- Enable **transparent backend swapping** (e.g., migrating from MySQL/Redis to PostgreSQL) without touching consumer code.

- Avoid patching libraries that already depend on `IDistributedCache` (Sessions, Data Protection, etc.).

- Simplify testing/mocking in applications that expect the standard contract.

#### ✅ **Impact**

- **Breaking Change?** Not for consumers who **use** the interface; they only need to update the package and rebuild.

- Projects that **implement** `IPostgreSqlDistributedCache` must now provide the four additional methods, but we expect most implementations to be internal to the package.

#### ✔️ **Suggested next steps**

- Update README and usage samples.

- Publish a new version (patch or minor, according to repo policy).

- Open a follow-up issue to decide whether PostgreSQL-specific methods should be added via extension methods instead of interface members.
